### PR TITLE
Using a regex to find an actual word to translate in context, and not…

### DIFF
--- a/python_translators/translation_query.py
+++ b/python_translators/translation_query.py
@@ -67,7 +67,6 @@ class TranslationQuery(object):
             max_translations=max_translations,
         )
 
-    @classmethod
     def is_context_aware_request(self):
         return self.before_context or self.after_context
 

--- a/python_translators/translation_query.py
+++ b/python_translators/translation_query.py
@@ -54,7 +54,8 @@ class TranslationQuery(object):
         Note: the current implementation does not use the word_index_for_query
         """
 
-        result = re.search(r"\b" + re.escape(query) + r"\b", context).span()
+        # using rf together based on: https://stackoverflow.com/a/55810892
+        result = re.search(rf"\b{query}\b", context).span()
 
         before_context = context[0 : result[0]]
         after_context = context[result[1] :]

--- a/python_translators/translation_query.py
+++ b/python_translators/translation_query.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 
 class TranslationBudget(object):
@@ -14,12 +15,14 @@ class TranslationBudget(object):
 
 
 class TranslationQuery(object):
-    def __init__(self,
-                 query: str,
-                 before_context: str = '',
-                 after_context: str = '',
-                 max_translations: int = 1,
-                 budget: TranslationBudget = None):
+    def __init__(
+        self,
+        query: str,
+        before_context: str = "",
+        after_context: str = "",
+        max_translations: int = 1,
+        budget: TranslationBudget = None,
+    ):
         self.query = query
         self.before_context = before_context
         self.after_context = after_context
@@ -36,59 +39,34 @@ class TranslationQuery(object):
         return self.budget.is_unconstrained()
 
     @classmethod
-    def for_word_occurrence(cls, query: str, context: str, word_index_for_query: int, max_translations: int = 1):
-
+    def for_word_occurrence(
+        cls,
+        query: str,
+        context: str,
+        word_index_for_query: int,
+        max_translations: int = 1,
+    ):
         """
-            Useful when context is given as a single paragraph, but it's known which occurrence of
-            the query is interesting (in the situation where there's multiple occurrences of query
-            in the context)
+        Useful when context is given as a single paragraph, but it's known which occurrence of
+        the query is interesting (in the situation where there's multiple occurrences of query
+        in the context)
+
+        Note: the current implementation does not use the word_index_for_query
         """
-        result = context.split(query, word_index_for_query)
-        before_context = after_context = ''
 
-        if len(result) > 1:
-            before_context, after_context = result[0], result[1]
+        result = re.search(r"\b" + re.escape(query) + r"\b", context).span()
 
-        return cls(query, before_context=before_context, after_context=after_context, max_translations=max_translations)
+        before_context = context[0 : result[0]]
+        after_context = context[result[1] + len(query) :]
+
+        return cls(
+            query,
+            before_context=before_context,
+            after_context=after_context,
+            max_translations=max_translations,
+        )
 
     @classmethod
-    def for_word_at_index(cls, query: str, context: str, char_index: int, max_translations: int = 1):
-
-        """
-            Convenient when context is given as a whole.
-            The char_index insures that in case of multiple occurrences of the query in the context
-             the right one is being translated.
-        """
-        before_context, after_context = context[:char_index], context[:char_index + len(query)]
-        return cls(query, before_context=before_context, after_context=after_context, max_translations=max_translations)
-
-    @classmethod
-    def one_context_and_word_index(cls, query: str, context: str, word_index_for_query: int, max_translations: int = 1):
-
-        """
-
-            Useful when context is given as a single paragraph, but it's known which occurrence of
-            the query is interesting (in the situation where there's multiple occurrences of query
-            in the context)
-
-        """
-        before_context, after_context = context.split(query, word_index_for_query)
-        return cls(query, before_context=before_context, after_context=after_context, max_translations=max_translations)
-
-    @classmethod
-    def one_context_and_char_index(cls, query: str, context: str, char_index: int, max_translations: int = 1):
-
-        """
-
-            Convenient when context is given as a whole.
-
-            The char_index insures that in case of multiple occurrences of the query in the context
-             the right one is being translated.
-
-        """
-        before_context, after_context = context[:char_index], context[:char_index + len(query)]
-        return cls(query, before_context=before_context, after_context=after_context, max_translations=max_translations)
-
     def is_context_aware_request(self):
         return self.before_context or self.after_context
 

--- a/python_translators/translation_query.py
+++ b/python_translators/translation_query.py
@@ -43,7 +43,7 @@ class TranslationQuery(object):
         cls,
         query: str,
         context: str,
-        word_index_for_query: int,
+        word_index_for_query: int = 1,
         max_translations: int = 1,
     ):
         """
@@ -57,7 +57,7 @@ class TranslationQuery(object):
         result = re.search(r"\b" + re.escape(query) + r"\b", context).span()
 
         before_context = context[0 : result[0]]
-        after_context = context[result[1] + len(query) :]
+        after_context = context[result[1] :]
 
         return cls(
             query,

--- a/tests/query_processors/test_create_query_for_word_and_context.py
+++ b/tests/query_processors/test_create_query_for_word_and_context.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from python_translators.query_processors.escape_html import EscapeHtml
+from python_translators.translation_query import TranslationQuery
+
+
+class TestCreateQueryForWordAndContext(TestCase):
+    def setUp(self):
+        self.query_processor = EscapeHtml()
+
+    def test_word_at_the_end(self):
+
+        query = TranslationQuery.for_word_occurrence(
+            "for", "Det er der faktisk en simpel formel for."
+        )
+        self.assertEqual(query.before_context, "Det er der faktisk en simpel formel ")
+        self.assertEqual(query.after_context, ".")
+        self.assertEqual(query.query, "for")
+
+    def test_word_in_the_middle(self):
+        context = "Det er der faktisk en simpel formel for."
+        word_str = "faktisk"
+
+        query = TranslationQuery.for_word_occurrence(word_str, context)
+        self.assertEqual(query.before_context, "Det er der ")
+        self.assertEqual(query.query, "faktisk")
+        print(query.after_context)
+        self.assertEqual(query.after_context, " en simpel formel for.")

--- a/tests/query_processors/test_escape_html.py
+++ b/tests/query_processors/test_escape_html.py
@@ -9,15 +9,13 @@ class TestEscapeHtml(TestCase):
 
     def test_escaping(self):
         q = TranslationQuery(
-            before_context='"Hello", ',
-            query='said',
-            after_context="the man."
+            before_context='"Hello", ', query="said", after_context="the man."
         )
 
         result = self.query_processor.process_query(q)
 
-        self.assertEqual(result.before_context, '&quot;Hello&quot;, ')
+        self.assertEqual(result.before_context, "&quot;Hello&quot;, ")
 
         # query and after_context should remain the same
-        self.assertEquals(result.query, q.query)
-        self.assertEquals(result.after_context, q.after_context)
+        self.assertEqual(result.query, q.query)
+        self.assertEqual(result.after_context, q.after_context)

--- a/tests/translation_caches/test_translation_cache_key.py
+++ b/tests/translation_caches/test_translation_cache_key.py
@@ -8,16 +8,20 @@ import copy
 class TestGoogleTranslator(TestCase):
     def setUp(self):
         self.q1 = TranslationQuery(
-            before_context='De directeur',
-            query='treedt af',
-            after_context=''
+            before_context="De directeur", query="treedt af", after_context=""
         )
 
         self.q2 = copy.deepcopy(self.q1)
 
-        self.k1 = caches.CacheKey(query=self.q1, source_language='nl', target_language='en')
-        self.k2 = caches.CacheKey(query=self.q2, source_language='nl', target_language='en')
-        self.k3 = caches.CacheKey(query=self.q1, source_language='nl', target_language='es')
+        self.k1 = caches.CacheKey(
+            query=self.q1, source_language="nl", target_language="en"
+        )
+        self.k2 = caches.CacheKey(
+            query=self.q2, source_language="nl", target_language="en"
+        )
+        self.k3 = caches.CacheKey(
+            query=self.q1, source_language="nl", target_language="es"
+        )
 
     def test_equal_to_itself(self):
         self.assertEqual(self.k1, self.k1)
@@ -26,18 +30,40 @@ class TestGoogleTranslator(TestCase):
         self.assertEqual(self.k1, self.k2)
 
     def test_equal_queries_but_distinct_languages(self):
-        self.assertNotEqual(self.k1, caches.CacheKey(query=self.q1, source_language='nl', target_language='es'))
+        self.assertNotEqual(
+            self.k1,
+            caches.CacheKey(query=self.q1, source_language="nl", target_language="es"),
+        )
 
     def test_key_is_hashable(self):
-        d = {
-            self.k1: 'k1',
-            self.k3: 'k3'
-        }
+        d = {self.k1: "k1", self.k3: "k3"}
 
-        self.assertEquals(d[caches.CacheKey(
-            query=TranslationQuery(before_context='De directeur', query='treedt af', after_context=''),
-            source_language='nl', target_language='en')], 'k1')
+        self.assertEqual(
+            d[
+                caches.CacheKey(
+                    query=TranslationQuery(
+                        before_context="De directeur",
+                        query="treedt af",
+                        after_context="",
+                    ),
+                    source_language="nl",
+                    target_language="en",
+                )
+            ],
+            "k1",
+        )
 
-        self.assertEquals(d[caches.CacheKey(
-            query=TranslationQuery(before_context='De directeur', query='treedt af', after_context=''),
-            source_language='nl', target_language='es')], 'k3')
+        self.assertEqual(
+            d[
+                caches.CacheKey(
+                    query=TranslationQuery(
+                        before_context="De directeur",
+                        query="treedt af",
+                        after_context="",
+                    ),
+                    source_language="nl",
+                    target_language="es",
+                )
+            ],
+            "k3",
+        )

--- a/tests/translators/test_best_effort_translator.py
+++ b/tests/translators/test_best_effort_translator.py
@@ -1,58 +1,68 @@
 from unittest import TestCase
 
 from python_translators.translation_query import TranslationQuery
-from python_translators.translators.best_effort_translator import DummyBestEffortTranslator, BestEffortTranslator
+from python_translators.translators.best_effort_translator import (
+    DummyBestEffortTranslator,
+    BestEffortTranslator,
+)
 
 
 class TestBestEffortTranslator(TestCase):
 
     def setUp(self):
-        self.translator = DummyBestEffortTranslator(source_language='de', target_language='en')
-        self.bet = BestEffortTranslator(source_language='de', target_language='en')
+        self.translator = DummyBestEffortTranslator(
+            source_language="de", target_language="en"
+        )
+        self.bet = BestEffortTranslator(source_language="de", target_language="en")
 
     def testEnsureDifferentWordThanOriginalReturnedIfPossible(self):
-        response = self.translator.translate(TranslationQuery(
-            query="ada",
-            max_translations=1
-        ))
+        response = self.translator.translate(
+            TranslationQuery(query="ada", max_translations=1)
+        )
 
-        self.assertNotEqual(response.translations[0]['translation'], 'ada')
+        self.assertNotEqual(response.translations[0]["translation"], "ada")
 
     def testEnsureContextualHasPriority(self):
-        response = self.bet.translate(TranslationQuery(
-            before_context='Hunderte Züge und Dutzende Flüge wurden ',
-            query='gestrichen',
-            after_context=' .',
-            max_translations=3
-        ))
+        response = self.bet.translate(
+            TranslationQuery(
+                before_context="Hunderte Züge und Dutzende Flüge wurden ",
+                query="gestrichen",
+                after_context=" .",
+                max_translations=3,
+            )
+        )
 
-        assert (response.translations[0]['translation'] == "canceled")
+        assert response.translations[0]["translation"] == "cancelled"
 
     def test_issue_20__avoidance_of_suspiciously_long_translations(self):
         # source of example:
         # http://www.spiegel.de/lebenundlernen/job/equal-pay-day-warum-die-deutschen-nicht-ueber-geld-reden-a-1198494.html
-        response = self.bet.translate(TranslationQuery(
-            before_context='Der amerikanische Traum wurzelt in dem Glauben, dass der ',
-            query='Einzelne',
-            after_context=' es vom Tellerwäscher zum Milliardär schaffen kann.',
-            max_translations=3
-        ))
+        response = self.bet.translate(
+            TranslationQuery(
+                before_context="Der amerikanische Traum wurzelt in dem Glauben, dass der ",
+                query="Einzelne",
+                after_context=" es vom Tellerwäscher zum Milliardär schaffen kann.",
+                max_translations=3,
+            )
+        )
 
         # this works only after we 'half' the importance of the Google -- with context which
         # translated more than the actual query normally
         # [{'translation': 'individual', 'service_name': 'Microsoft - with context', 'quality': 75},
         # {'translation': 'Single', 'service_name': 'Google - without context', 'quality': 70},
         # {'translation': 'individual can make', 'quality': 40, 'service_name': 'Google - with context'}]
-        assert (response.translations[0]['translation'] in ["individual", "individuals"])
+        assert response.translations[0]["translation"] in ["individual", "individuals"]
 
     def test_issue_41__avoidance_of_empty_strings(self):
         # source of example:
         # http://www.spiegel.de/panorama/justiz/indiana-bankraeuber-kam-mit-dem-taxi-a-1198724.html
-        response = self.bet.translate(TranslationQuery(
-            before_context='Nach der Fahrt zu der Bank ',
-            query='schob',
-            after_context=' er dem Angestellten an der Kasse lediglich einen Zettel zu: "Dies ist ein Überfall.',
-            max_translations=3
-        ))
+        response = self.bet.translate(
+            TranslationQuery(
+                before_context="Nach der Fahrt zu der Bank ",
+                query="schob",
+                after_context=' er dem Angestellten an der Kasse lediglich einen Zettel zu: "Dies ist ein Überfall.',
+                max_translations=3,
+            )
+        )
 
-        assert (response.translations[0]['translation'] != "")
+        assert response.translations[0]["translation"] != ""

--- a/tests/translators/test_chinese.py
+++ b/tests/translators/test_chinese.py
@@ -23,9 +23,7 @@ class TestMicrosoftTranslator(TestCase):
         )
 
         m_response = self.microsoft.translate(query)
-        print(m_response.translations)
         g_response = self.google.translate(query)
-        print(g_response.translations)
 
         self.assertTrue(
             m_response.get_raw_translations() == g_response.get_raw_translations()

--- a/tests/translators/test_chinese.py
+++ b/tests/translators/test_chinese.py
@@ -1,26 +1,32 @@
 # -*- coding: utf8 -*-
 from unittest import TestCase
 
-from python_translators.factories.google_translator_factory import GoogleTranslatorFactory
+from python_translators.factories.google_translator_factory import (
+    GoogleTranslatorFactory,
+)
 from python_translators.translation_query import TranslationQuery
-from python_translators.factories.microsoft_translator_factory import MicrosoftTranslatorFactory
+from python_translators.factories.microsoft_translator_factory import (
+    MicrosoftTranslatorFactory,
+)
 
 
 class TestMicrosoftTranslator(TestCase):
     def setUp(self):
-        self.microsoft = MicrosoftTranslatorFactory.build_with_context('en', 'zh-CN')
+        self.microsoft = MicrosoftTranslatorFactory.build_with_context("en", "zh-CN")
 
         # language codes for google from: https://ctrlq.org/code/19899-google-translate-languages
-        self.google = GoogleTranslatorFactory.build_with_context('en', 'zh-CN')
+        self.google = GoogleTranslatorFactory.build_with_context("en", "zh-CN")
 
     def test_water_is_water_in_both_google_and_microsoft(self):
         query = TranslationQuery(
-            before_context='This',
-            query='water',
-            after_context='is good')
+            before_context="This", query="water", after_context="is good"
+        )
 
         m_response = self.microsoft.translate(query)
+        print(m_response.translations)
         g_response = self.google.translate(query)
+        print(g_response.translations)
 
-        self.assertTrue(m_response.get_raw_translations() == g_response.get_raw_translations())
-
+        self.assertTrue(
+            m_response.get_raw_translations() == g_response.get_raw_translations()
+        )

--- a/tests/translators/test_google_translator.py
+++ b/tests/translators/test_google_translator.py
@@ -1,148 +1,183 @@
 # -*- coding: utf8 -*-
 from unittest import TestCase
 from python_translators.translation_query import TranslationQuery
-from python_translators.factories.google_translator_factory import GoogleTranslatorFactory
+from python_translators.factories.google_translator_factory import (
+    GoogleTranslatorFactory,
+)
 from python_translators.translators.translator import Translator
 
 
 class TestGoogleTranslator(TestCase):
     def setUp(self):
         self.translators: [Translator] = {
-            'en-nl': GoogleTranslatorFactory.build_with_context('en', 'nl'),
-            'es-en': GoogleTranslatorFactory.build_with_context('es', 'en'),
-            'de-en': GoogleTranslatorFactory.build_with_context('de', 'en'),
-            'en-de': GoogleTranslatorFactory.build_with_context('en', 'de'),
-            'nl-en': GoogleTranslatorFactory.build_with_context('nl', 'en')
+            "en-nl": GoogleTranslatorFactory.build_with_context("en", "nl"),
+            "es-en": GoogleTranslatorFactory.build_with_context("es", "en"),
+            "de-en": GoogleTranslatorFactory.build_with_context("de", "en"),
+            "en-de": GoogleTranslatorFactory.build_with_context("en", "de"),
+            "nl-en": GoogleTranslatorFactory.build_with_context("nl", "en"),
         }
 
     def testContextMatters(self):
-        response = self.translators['en-nl'].translate(TranslationQuery(
-            before_context='Dark',
-            query='matter',
-            after_context='is to be found in the universe'))
+        response = self.translators["en-nl"].translate(
+            TranslationQuery(
+                before_context="Dark",
+                query="matter",
+                after_context="is to be found in the universe",
+            )
+        )
 
-        self.assertEqual(response.get_raw_translations()[0], 'materie')
+        self.assertEqual(response.get_raw_translations()[0], "materie")
 
     def testWithoutContext(self):
-        response = self.translators['nl-en'].translate(TranslationQuery(
-            query='boom'
-        ))
+        response = self.translators["nl-en"].translate(TranslationQuery(query="boom"))
 
-        self.assertEquals(response.get_raw_translations()[0], 'tree')
+        self.assertEqual(response.get_raw_translations()[0], "tree")
 
     def testSuffixIsEmpty(self):
-        response = self.translators['es-en'].translate(TranslationQuery(
-            before_context='Estoy en la',
-            query='cama',
-            after_context=''))
+        response = self.translators["es-en"].translate(
+            TranslationQuery(
+                before_context="Estoy en la", query="cama", after_context=""
+            )
+        )
 
-        self.assertEqual(response.get_raw_translations()[0], 'bed')
+        self.assertEqual(response.get_raw_translations()[0], "bed")
 
     def testUnicodeCharactersInContext(self):
-        response = self.translators['de-en'].translate(TranslationQuery(
-            before_context='Ein',
-            query='klein',
-            after_context=u'löwe'))
+        response = self.translators["de-en"].translate(
+            TranslationQuery(before_context="Ein", query="klein", after_context="löwe")
+        )
 
         # our translators change their mind sometimes, so we provide
         # two options for the translation so this test does not fail
-        assert(response.get_raw_translations()[0] in ["little", "small"])
+        assert response.get_raw_translations()[0] in ["little", "small"]
 
     def testUnicodeCharactersInWordToTranslate(self):
-        response = self.translators['de-en'].translate(TranslationQuery(
-            before_context=u'Die schön',
-            query=u'löwen',
-            after_context=u' geht zum Wald'))
+        response = self.translators["de-en"].translate(
+            TranslationQuery(
+                before_context="Die schön",
+                query="löwen",
+                after_context=" geht zum Wald",
+            )
+        )
 
-        self.assertIn(response.get_raw_translations()[0], ['lion', 'beautiful lion'])
+        self.assertIn(response.get_raw_translations()[0], ["lion", "beautiful lion"])
 
     def testUnicodeInResult(self):
-        response = self.translators['en-de'].translate(TranslationQuery(
-            before_context='The ',
-            query='lion',
-            after_context=' goes to the forrest.'))
+        response = self.translators["en-de"].translate(
+            TranslationQuery(
+                before_context="The ",
+                query="lion",
+                after_context=" goes to the forrest.",
+            )
+        )
 
-        self.assertEqual(response.get_raw_translations()[0], u'Löwe')
+        self.assertEqual(response.get_raw_translations()[0], "Löwe")
 
     def testSuffixStartsWithPunctuation(self):
-        response = self.translators['es-en'].translate(TranslationQuery(
-            before_context='Estoy en la',
-            query='cama',
-            after_context=', e soy dormiendo'))
+        response = self.translators["es-en"].translate(
+            TranslationQuery(
+                before_context="Estoy en la",
+                query="cama",
+                after_context=", e soy dormiendo",
+            )
+        )
 
-        self.assertEqual(response.get_raw_translations()[0], 'bed')
+        self.assertEqual(response.get_raw_translations()[0], "bed")
 
-        response = self.translators['es-en'].translate(TranslationQuery(
-            before_context='Estoy en la',
-            query='cama',
-            after_context=' , e soy dormiendo'))
+        response = self.translators["es-en"].translate(
+            TranslationQuery(
+                before_context="Estoy en la",
+                query="cama",
+                after_context=" , e soy dormiendo",
+            )
+        )
 
-        self.assertEqual(response.get_raw_translations()[0], 'bed')
+        self.assertEqual(response.get_raw_translations()[0], "bed")
 
     def testQueryEndsWithPunctuation(self):
-        translation = self.translators['es-en'].translate(TranslationQuery(
-            before_context='Estoy en la',
-            query='cama,',
-            after_context=' e soy dormiendo'))
+        translation = self.translators["es-en"].translate(
+            TranslationQuery(
+                before_context="Estoy en la",
+                query="cama,",
+                after_context=" e soy dormiendo",
+            )
+        )
 
-        self.assertIn(translation.get_raw_translations()[0], ['bed,', 'bed'])
+        self.assertIn(translation.get_raw_translations()[0], ["bed,", "bed"])
 
     def test_strange_span_in_return(self):
-        response = self.translators['de-en'].translate(TranslationQuery(
-            before_context='Ich hatte mich',
-            query='eigentlich schon',
-            after_context=' mit dem 1:1-Unentschieden abgefunden'))
+        response = self.translators["de-en"].translate(
+            TranslationQuery(
+                before_context="Ich hatte mich",
+                query="eigentlich schon",
+                after_context=" mit dem 1:1-Unentschieden abgefunden",
+            )
+        )
 
         self.assertNotIn("</span>", response.get_raw_translations()[0])
 
     def test_escaped_characters_in_translation(self):
-        response = self.translators['de-en'].translate(TranslationQuery(
-            before_context=u'Um Fernbusse aus dem Geschäft zu drängen, hat das Unternehmen damit begonnen, das',
-            query='konzerneigene Flaggschiff',
-            after_context=u'ICE straßentauglich zu machen. '))
+        response = self.translators["de-en"].translate(
+            TranslationQuery(
+                before_context="Um Fernbusse aus dem Geschäft zu drängen, hat das Unternehmen damit begonnen, das",
+                query="konzerneigene Flaggschiff",
+                after_context="ICE straßentauglich zu machen. ",
+            )
+        )
 
-        self.assertNotIn('&#39;', response.get_raw_translations()[0])
+        self.assertNotIn("&#39;", response.get_raw_translations()[0])
 
     def test_encoding_issue(self):
-        response = self.translators['nl-en'].translate(TranslationQuery(
-            before_context='De verkiezingscommissie bestaat uit vertegenwoordigers uit verschillende geledingen van '
-                           'de universiteit en moet over de goede gang van zaken waken voor en tijdens de',
-            query='rectorverkiezing',
-            after_context='. De Leuvense studenten hebben deze ochtend laten weten er niet meer aan deel te willen '
-                          'nemen. Dat meldt het studentenblad Veto en wordt bevestigd aan onze redactie.'
-        ))
+        response = self.translators["nl-en"].translate(
+            TranslationQuery(
+                before_context="De verkiezingscommissie bestaat uit vertegenwoordigers uit verschillende geledingen van "
+                "de universiteit en moet over de goede gang van zaken waken voor en tijdens de",
+                query="rectorverkiezing",
+                after_context=". De Leuvense studenten hebben deze ochtend laten weten er niet meer aan deel te willen "
+                "nemen. Dat meldt het studentenblad Veto en wordt bevestigd aan onze redactie.",
+            )
+        )
 
-        self.assertIn(response.get_raw_translations()[0], ['rector\'s election', 'presidential election',
-                                                           'rector election'])
+        self.assertIn(
+            response.get_raw_translations()[0],
+            ["rector's election", "presidential election", "rector election"],
+        )
 
     def test_html_in_query(self):
-        response = self.translators['nl-en'].translate(TranslationQuery(
-            query='m\'n maat'
-        ))
+        response = self.translators["nl-en"].translate(
+            TranslationQuery(query="m'n maat")
+        )
 
-        assert (response.get_raw_translations()[0] in ['my size', 'my partner', 'my mate'])
+        assert response.get_raw_translations()[0] in [
+            "my size",
+            "my partner",
+            "my mate",
+        ]
 
     def test_issue_29(self):
-        response = self.translators['nl-en'].translate(TranslationQuery(
-            query="K'ratak is een klingon"
-        ))
+        response = self.translators["nl-en"].translate(
+            TranslationQuery(query="K'ratak is een klingon")
+        )
 
         self.assertEqual(response.get_raw_translations()[0], "K'ratak is a klingon")
 
     def test_issue_20__many_words_returned(self):
-        res = self.translators['de-en'].translate(TranslationQuery(
-            before_context='Die Nato-Partner Amerikas ',
-            query='guckten',
-            after_context=' betreten, als Trump ihnen in Brüssel vorhielt, sie sollten gefälligst ihre Verteidigungsbudgets ausbauen und entsprechend ihrer Zusage zwei Prozent des Bruttoinlandsproduktes fürs Militär ausgeben. Damit nährt er den alten Verdacht, Trump '
-        ))
+        res = self.translators["de-en"].translate(
+            TranslationQuery(
+                before_context="Die Nato-Partner Amerikas ",
+                query="guckten",
+                after_context=" betreten, als Trump ihnen in Brüssel vorhielt, sie sollten gefälligst ihre Verteidigungsbudgets ausbauen und entsprechend ihrer Zusage zwei Prozent des Bruttoinlandsproduktes fürs Militär ausgeben. Damit nährt er den alten Verdacht, Trump ",
+            )
+        )
         first_translation = res.get_raw_translations()[0]
-        self.assertTrue(len(first_translation)<20)
-
+        self.assertTrue(len(first_translation) < 20)
 
     def test_issue_31__commma_in_response(self):
-        res = self.translators['de-en'].translate(TranslationQuery(
-            before_context='Nach ersten Abschnitten am Wochenende sei die Wasserstraße nun komplett  ',
-            query='dicht',
-            after_context=', sagte eine Sprecherin des Wasserstraßen- und Schifffahrtsamtes (WSA)'
-        ))
+        res = self.translators["de-en"].translate(
+            TranslationQuery(
+                before_context="Nach ersten Abschnitten am Wochenende sei die Wasserstraße nun komplett  ",
+                query="dicht",
+                after_context=", sagte eine Sprecherin des Wasserstraßen- und Schifffahrtsamtes (WSA)",
+            )
+        )
         self.assertFalse("," in res.get_raw_translations()[0])

--- a/tests/translators/test_microsoft_translator.py
+++ b/tests/translators/test_microsoft_translator.py
@@ -3,66 +3,69 @@ import unittest
 from unittest import TestCase
 from python_translators.translators.microsoft_translator import MicrosoftTranslator
 from python_translators.translation_query import TranslationQuery
-from python_translators.factories.microsoft_translator_factory import MicrosoftTranslatorFactory
+from python_translators.factories.microsoft_translator_factory import (
+    MicrosoftTranslatorFactory,
+)
 
 
 class TestMicrosoftTranslator(TestCase):
     def setUp(self):
         self.translators = {
-            'en-nl': MicrosoftTranslatorFactory.build_with_context('en', 'nl'),
-            'nl-en': MicrosoftTranslatorFactory.build_with_context('nl', 'en'),
-            'es-en': MicrosoftTranslatorFactory.build_with_context('es', 'en'),
-            'de-en': MicrosoftTranslatorFactory.build_with_context('de', 'en'),
-            'en-de': MicrosoftTranslatorFactory.build_with_context('en', 'de'),
+            "en-nl": MicrosoftTranslatorFactory.build_with_context("en", "nl"),
+            "nl-en": MicrosoftTranslatorFactory.build_with_context("nl", "en"),
+            "es-en": MicrosoftTranslatorFactory.build_with_context("es", "en"),
+            "de-en": MicrosoftTranslatorFactory.build_with_context("de", "en"),
+            "en-de": MicrosoftTranslatorFactory.build_with_context("en", "de"),
         }
 
     def test_simple_translations(self):
-        response = self.translators['en-nl'].translate(TranslationQuery(
-            query='hello'))
+        response = self.translators["en-nl"].translate(TranslationQuery(query="hello"))
 
-        self.assertEqual(response.get_raw_translations()[0], 'Hallo')
+        self.assertEqual(response.get_raw_translations()[0], "Hallo")
 
     def test_invalid_microsoft_key(self):
-        self.assertRaises(Exception, MicrosoftTranslator, '<this is an invalid key>')
+        self.assertRaises(Exception, MicrosoftTranslator, "<this is an invalid key>")
 
     def test_ca_translations(self):
-        response = self.translators['nl-en'].translate(TranslationQuery(
-            before_context='De directeur',
-            query='treedt af',
-            after_context=''
-        ))
+        response = self.translators["nl-en"].translate(
+            TranslationQuery(
+                before_context="De directeur", query="treedt af", after_context=""
+            )
+        )
         translation = response.get_raw_translations()[0]
-        self.assertIn(translation, ['shall resign', 'resigns'])  # was 'shall resign' but not anymore as of 2020
+        self.assertIn(
+            translation, ["shall resign", "resigns"]
+        )  # was 'shall resign' but not anymore as of 2020
 
-        response = self.translators['en-nl'].translate(TranslationQuery(
-            before_context='Dark',
-            query='matter',
-            after_context='is an unidentified type of matter distinct from dark energy.'
-        ))
+        response = self.translators["en-nl"].translate(
+            TranslationQuery(
+                before_context="Dark",
+                query="matter",
+                after_context="is an unidentified type of matter distinct from dark energy.",
+            )
+        )
         translation = response.get_raw_translations()[0]
-        self.assertEqual('materie', translation)
+        self.assertEqual("materie", translation)
 
     def test_unicode_outputs(self):
-        response = self.translators['en-de'].translate(TranslationQuery(
-            before_context='The ',
-            query='lion',
-            after_context='goes to the forest'
-        ))
+        response = self.translators["en-de"].translate(
+            TranslationQuery(
+                before_context="The ", query="lion", after_context="goes to the forest"
+            )
+        )
 
-        self.assertEqual(u'Löwe', response.get_raw_translations()[0])
+        self.assertEqual("Löwe", response.get_raw_translations()[0])
 
     def test_unicode_inputs(self):
-        response = self.translators['de-en'].translate(TranslationQuery(
-            query=u'Löwe'
-        ))
-
-        self.assertEqual('Lion', response.get_raw_translations()[0])
+        response = self.translators["de-en"].translate(TranslationQuery(query="Löwe"))
+        print(response.get_raw_translations()[0])
+        self.assertEqual("lion", response.get_raw_translations()[0].lower())
 
     def test_html_chars(self):
-        response = self.translators['nl-en'].translate(TranslationQuery(
-            query="m'n maat"
-        ))
+        response = self.translators["nl-en"].translate(
+            TranslationQuery(query="m'n maat")
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/translators/test_wordnik_translator.py
+++ b/tests/translators/test_wordnik_translator.py
@@ -9,55 +9,19 @@ from python_translators.config import get_key_from_config
 class TestWordnikTranslator(TestCase):
 
     def setUp(self):
-        self.translator = WordnikTranslator(source_language='es',
-                                            target_language='en',
-                                            key=get_key_from_config('WORDNIK_API_KEY'))
-
-    def testNumberOfTranslationsWorks(self):
-        response = self.translator.translate(TranslationQuery(
-            query="conjunction",
-            max_translations=5
-        ))
-
-        assert 2 <= len(response.translations)
+        self.translator = WordnikTranslator(
+            source_language="es",
+            target_language="en",
+            key=get_key_from_config("WORDNIK_API_KEY"),
+        )
 
     def testUppercaseMatters(self):
-        response = self.translator.translate(TranslationQuery(
-            query="March",
-            max_translations=5
-        ))
-        response2 = self.translator.translate(TranslationQuery(
-            query="march",
-            max_translations=5
-        ))
+        response = self.translator.translate(
+            TranslationQuery(query="March", max_translations=5)
+        )
+        response2 = self.translator.translate(
+            TranslationQuery(query="march", max_translations=5)
+        )
 
         # The first is the month; the second is the verb
         assert response.translations != response2.translations
-
-    def testWordnikShouldLowercaseByItself(self):
-        response = self.translator.translate(TranslationQuery(
-            query="Conjunction",
-            max_translations=5
-        ))
-
-        self.assertFalse(response.translations == [])
-
-    def testQuotedWord(self):
-        response1 = self.translator.translate(TranslationQuery(
-            query="'insincere'",
-            max_translations=5
-        ))
-
-        response2 = self.translator.translate(TranslationQuery(
-            query="insincere",
-            max_translations=5
-        ))
-
-        response3 = self.translator.translate(TranslationQuery(
-            query=''"insincere"'',
-            max_translations=5
-        ))
-
-        assert (len(response1.translations) ==
-                len(response2.translations) ==
-                len(response3.translations))


### PR DESCRIPTION
This fixes the glaring problem we have for now (see https://github.com/zeeguu/api/issues/315 in the zeeguu api repo). In the future we should add another utility function here that works with alignments.